### PR TITLE
Point browser to SCA for accountInfo

### DIFF
--- a/src/common/actions/auth-store.js
+++ b/src/common/actions/auth-store.js
@@ -223,10 +223,11 @@ function checkSignedIntoStoreError(error) {
 }
 
 async function fetchAccountInfo(root, discharge) {
-  const query = { root, discharge };
-  const accountUrl = `${BASE_URL}/api/store/account?${qs.stringify(query)}`;
-  const response = await fetch(accountUrl, {
-    headers: { 'Accept': 'application/json' }
+  const response = await fetch(`${conf.get('STORE_API_URL')}/account`, {
+    headers: {
+      'Authorization': `Macaroon root="${root}", discharge="${discharge}"`,
+      'Accept': 'application/json'
+    }
   });
   if (response.status >= 200 && response.status < 300) {
     return { signedAgreement: true, hasShortNamespace: true };

--- a/src/common/actions/auth-store.js
+++ b/src/common/actions/auth-store.js
@@ -11,6 +11,7 @@ import { getCaveats } from '../helpers/macaroons';
 import { getPackageUploadRequestMacaroon } from './register-name';
 
 const BASE_URL = conf.get('BASE_URL');
+const STORE_API_URL = conf.get('STORE_API_URL');
 
 export const SIGN_INTO_STORE = 'SIGN_INTO_STORE';
 export const SIGN_INTO_STORE_SUCCESS = 'SIGN_INTO_STORE_SUCCESS';
@@ -28,7 +29,7 @@ export const SIGN_AGREEMENT_SUCCESS = 'SIGN_AGREEMENT_SUCCESS';
 export const SIGN_OUT_OF_STORE_ERROR = 'SIGN_OUT_OF_STORE_ERROR';
 
 export function extractExpiresCaveat(macaroon) {
-  const storeLocation = url.parse(conf.get('STORE_API_URL')).host;
+  const storeLocation = url.parse(STORE_API_URL).host;
   for (const caveat of getCaveats(macaroon)) {
     if (caveat.verificationKeyId === '') {
       const parts = caveat.caveatId.split('|');
@@ -58,7 +59,7 @@ export function extractSSOCaveat(macaroon) {
 async function getPackageUploadRequestPermission() {
   const lifetime = conf.get('STORE_PACKAGE_UPLOAD_REQUEST_LIFETIME');
 
-  const response = await fetch(`${conf.get('STORE_API_URL')}/acl/`, {
+  const response = await fetch(`${STORE_API_URL}/acl/`, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
@@ -223,7 +224,7 @@ function checkSignedIntoStoreError(error) {
 }
 
 async function fetchAccountInfo(root, discharge) {
-  const response = await fetch(`${conf.get('STORE_API_URL')}/account`, {
+  const response = await fetch(`${STORE_API_URL}/account`, {
     headers: {
       'Authorization': `Macaroon root="${root}", discharge="${discharge}"`,
       'Accept': 'application/json'
@@ -252,7 +253,7 @@ async function fetchAccountInfo(root, discharge) {
 async function setShortNamespace(root, discharge, userName) {
   // Try setting the short namespace to the SSO username.  This may not
   // work, but it's the best we can do automatically.
-  const response = await fetch(`${conf.get('STORE_API_URL')}/account`, {
+  const response = await fetch(`${STORE_API_URL}/account`, {
     method: 'PATCH',
     headers: {
       'Authorization': `Macaroon root="${root}", discharge="${discharge}"`,

--- a/src/server/handlers/store.js
+++ b/src/server/handlers/store.js
@@ -16,29 +16,7 @@ export const getAccount = async (req, res) => {
   return res.status(response.status).send(json);
 };
 
-export const patchAccount = async (req, res) => {
-  const shortNamespace = req.body.short_namespace;
-  const root = req.body.root;
-  const discharge = req.body.discharge;
-
-  const response = await fetch(`${conf.get('STORE_API_URL')}/account`, {
-    method: 'PATCH',
-    headers: {
-      'Authorization': `Macaroon root="${root}", discharge="${discharge}"`,
-      'Content-Type': 'application/json'
-    },
-    body: JSON.stringify({ short_namespace: shortNamespace })
-  });
-  const text = await response.text();
-  let json;
-  if (text === '') {
-    json = null;
-  } else {
-    json = JSON.parse(text);
-  }
-  return res.status(response.status).send(json);
-};
-
+// XXX: Client can go straight to SCA for this now
 export const signAgreement = async (req, res) => {
   const latestTosAccepted = req.body.latest_tos_accepted;
   const root = req.body.root;

--- a/src/server/routes/store.js
+++ b/src/server/routes/store.js
@@ -3,7 +3,6 @@ import { json } from 'body-parser';
 
 import {
   getAccount,
-  patchAccount,
   signAgreement
 } from '../handlers/store';
 
@@ -11,7 +10,6 @@ const router = Router();
 
 router.use('/store/account', json());
 router.get('/store/account', getAccount);
-router.patch('/store/account', patchAccount);
 
 router.use('/store/agreement', json());
 router.post('/store/agreement', signAgreement);

--- a/src/server/routes/store.js
+++ b/src/server/routes/store.js
@@ -2,14 +2,10 @@ import { Router } from 'express';
 import { json } from 'body-parser';
 
 import {
-  getAccount,
   signAgreement
 } from '../handlers/store';
 
 const router = Router();
-
-router.use('/store/account', json());
-router.get('/store/account', getAccount);
 
 router.use('/store/agreement', json());
 router.post('/store/agreement', signAgreement);

--- a/test/routes/src/server/routes/t_store.js
+++ b/test/routes/src/server/routes/t_store.js
@@ -10,62 +10,6 @@ describe('The store API endpoint', () => {
   const app = Express();
   app.use(store);
 
-  describe('GET account route', () => {
-    afterEach(() => {
-      nock.cleanAll();
-    });
-
-    it('passes request through to store', (done) => {
-      const scope = nock(conf.get('STORE_API_URL'))
-        .get('/account')
-        .matchHeader(
-          'Authorization',
-          'Macaroon root="dummy-root", discharge="dummy-discharge"'
-        )
-        .reply(200, { account_id: 'test-account-id' });
-
-      supertest(app)
-        .get('/store/account')
-        .query({
-          root: 'dummy-root',
-          discharge: 'dummy-discharge'
-        })
-        .expect((res) => {
-          scope.done();
-          expect(res.status).toBe(200);
-          expect(res.body).toEqual({ account_id: 'test-account-id' });
-        })
-        .end(done);
-    });
-
-    it('handles error responses reasonably', (done) => {
-      const error = {
-        code: 'user-not-ready',
-        message: 'Developer has not signed agreement.'
-      };
-      const scope = nock(conf.get('STORE_API_URL'))
-        .get('/account')
-        .matchHeader(
-          'Authorization',
-          'Macaroon root="dummy-root", discharge="dummy-discharge"'
-        )
-        .reply(403, { error_list: [error] });
-
-      supertest(app)
-        .get('/store/account')
-        .query({
-          root: 'dummy-root',
-          discharge: 'dummy-discharge'
-        })
-        .expect((res) => {
-          scope.done();
-          expect(res.status).toBe(403);
-          expect(res.body).toEqual({ error_list: [error] });
-        })
-        .end(done);
-    });
-  });
-
   describe('sign agreement route', () => {
     afterEach(() => {
       nock.cleanAll();

--- a/test/routes/src/server/routes/t_store.js
+++ b/test/routes/src/server/routes/t_store.js
@@ -66,64 +66,6 @@ describe('The store API endpoint', () => {
     });
   });
 
-  describe('PATCH account route', () => {
-    afterEach(() => {
-      nock.cleanAll();
-    });
-
-    it('passes request through to store', (done) => {
-      const scope = nock(conf.get('STORE_API_URL'))
-        .patch('/account', { short_namespace: 'test-namespace' })
-        .matchHeader(
-          'Authorization',
-          'Macaroon root="dummy-root", discharge="dummy-discharge"'
-        )
-        .reply(204);
-
-      supertest(app)
-        .patch('/store/account')
-        .send({
-          short_namespace: 'test-namespace',
-          root: 'dummy-root',
-          discharge: 'dummy-discharge'
-        })
-        .expect((res) => {
-          scope.done();
-          expect(res.status).toBe(204);
-          expect(res.body).toEqual({});
-        })
-        .end(done);
-    });
-
-    it('handles error responses reasonably', (done) => {
-      const error = {
-        code: 'user-not-ready',
-        message: 'Developer has not signed agreement.'
-      };
-      const scope = nock(conf.get('STORE_API_URL'))
-        .patch('/account', { short_namespace: 'test-namespace' })
-        .matchHeader(
-          'Authorization',
-          'Macaroon root="dummy-root", discharge="dummy-discharge"'
-        )
-        .reply(403, { error_list: [error] });
-
-      supertest(app)
-        .patch('/store/account')
-        .send({
-          short_namespace: 'test-namespace',
-          root: 'dummy-root',
-          discharge: 'dummy-discharge'
-        })
-        .expect((res) => {
-          scope.done();
-          expect(res.status).toBe(403);
-          expect(res.body).toEqual({ error_list: [error] });
-        })
-        .end(done);
-    });
-  });
-
   describe('sign agreement route', () => {
     afterEach(() => {
       nock.cleanAll();

--- a/test/unit/src/common/actions/t_auth-store.js
+++ b/test/unit/src/common/actions/t_auth-store.js
@@ -440,14 +440,12 @@ describe('store authentication actions', () => {
   });
 
   context('getAccountInfo', () => {
-    let api;
     let storeApi;
 
     let root;
     let discharge;
 
     beforeEach(() => {
-      api = nock(`${conf.get('BASE_URL')}/api`);
       storeApi = nock(conf.get('STORE_API_URL'));
       const ssoLocation = url.parse(conf.get('UBUNTU_SSO_URL')).host;
       const rootMacaroon = new MacaroonsBuilder('location', 'key', 'id')
@@ -461,7 +459,6 @@ describe('store authentication actions', () => {
     });
 
     afterEach(() => {
-      api.done();
       storeApi.done();
       nock.cleanAll();
       localForageStub.clear();
@@ -508,7 +505,7 @@ describe('store authentication actions', () => {
       });
 
       it('stores an error on failure to get account information', async () => {
-        api.get('/store/account')
+        storeApi.get('/account')
           .query(true)
           .reply(501, { error_list: [accountAssertionsDisabledError] });
         await store.dispatch(getAccountInfo('test-user'));
@@ -521,7 +518,7 @@ describe('store authentication actions', () => {
 
       it('stores success action if getting account information succeeds ' +
          'and returns a short namespace', async () => {
-        api.get('/store/account')
+        storeApi.get('/account')
           .query(true)
           .reply(200, {});
         const expectedAction = {
@@ -534,7 +531,7 @@ describe('store authentication actions', () => {
 
       it('stores success action if getting account information fails ' +
          'because of an unsigned agreement', async () => {
-        api.get('/store/account')
+        storeApi.get('/account')
           .query(true)
           .reply(403, { error_list: [unsignedAgreementError] });
         const expectedAction = {
@@ -548,7 +545,7 @@ describe('store authentication actions', () => {
       context('if getting account information fails because of a missing ' +
               'short namespace', () => {
         beforeEach(() => {
-          api.get('/store/account')
+          storeApi.get('/account')
             .query(true)
             .reply(403, { error_list: [missingShortNamespaceError] });
         });
@@ -585,7 +582,7 @@ describe('store authentication actions', () => {
 
           it('stores an error if getting account information ' +
              'fails', async () => {
-            api.get('/store/account')
+            storeApi.get('/account')
               .query(true)
               .reply(501, { error_list: [accountAssertionsDisabledError] });
             await store.dispatch(getAccountInfo('test-user'));
@@ -598,7 +595,7 @@ describe('store authentication actions', () => {
 
           it('stores success action if getting account information ' +
              'succeeds', async () => {
-            api.get('/store/account')
+            storeApi.get('/account')
               .query(true)
               .reply(200, {});
             const expectedAction = {
@@ -611,7 +608,7 @@ describe('store authentication actions', () => {
 
           it('stores success action if getting account information fails ' +
              'because of an unsigned agreement', async () => {
-            api.get('/store/account')
+            storeApi.get('/account')
               .query(true)
               .reply(403, { error_list: [unsignedAgreementError] });
             const expectedAction = {

--- a/test/unit/src/common/actions/t_register-name.js
+++ b/test/unit/src/common/actions/t_register-name.js
@@ -349,7 +349,7 @@ describe('register name actions', () => {
                   code: 'user-not-ready',
                   message: 'Developer profile is missing short namespace.'
                 };
-                storeScope
+                storeApi
                   .get('/account')
                   .query(true)
                   .reply(403, { error_list: [error] })
@@ -357,7 +357,7 @@ describe('register name actions', () => {
                     short_namespace: 'test-user'
                   })
                   .reply(204);
-                storeScope
+                storeApi
                   .get('/account')
                   .query(true)
                   .reply(200, {});
@@ -375,7 +375,7 @@ describe('register name actions', () => {
               });
 
               it('leaves short namespace alone if already set', async () => {
-                storeScope
+                storeApi
                   .get('/account')
                   .query(true)
                   .reply(200, {});

--- a/test/unit/src/common/actions/t_register-name.js
+++ b/test/unit/src/common/actions/t_register-name.js
@@ -351,17 +351,16 @@ describe('register name actions', () => {
                   code: 'user-not-ready',
                   message: 'Developer profile is missing short namespace.'
                 };
-                scope
-                  .get('/api/store/account')
-                  .query(true)
-                  .reply(403, { error_list: [error] });
                 storeScope
+                  .get('/account')
+                  .query(true)
+                  .reply(403, { error_list: [error] })
                   .patch('/account', {
                     short_namespace: 'test-user'
                   })
                   .reply(204);
-                scope
-                  .get('/api/store/account')
+                storeScope
+                  .get('/account')
                   .query(true)
                   .reply(200, {});
 
@@ -378,8 +377,8 @@ describe('register name actions', () => {
               });
 
               it('leaves short namespace alone if already set', async () => {
-                scope
-                  .get('/api/store/account')
+                storeScope
+                  .get('/account')
                   .query(true)
                   .reply(200, {});
 

--- a/test/unit/src/common/actions/t_register-name.js
+++ b/test/unit/src/common/actions/t_register-name.js
@@ -355,8 +355,8 @@ describe('register name actions', () => {
                   .get('/api/store/account')
                   .query(true)
                   .reply(403, { error_list: [error] });
-                scope
-                  .patch('/api/store/account', {
+                storeScope
+                  .patch('/account', {
                     short_namespace: 'test-user'
                   })
                   .reply(204);


### PR DESCRIPTION
Note this depends on [a SCA MP](https://code.launchpad.net/~adam-collard/software-center-agent/add-cors-headers/+merge/322856) before it can be deployed. I figure it's worth getting :eyes: on this first :man_shrugging: 

Instead of talking to the backend proxy for `accountInfo` GET/PATCH directly to SCA. This removes one case of the security issue highlighted in #272